### PR TITLE
chore: adopt CodeGPT lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,89 @@
 version: "2"
+output:
+  sort-order:
+    - file
 linters:
   default: none
   enable:
-    - dogsled
-    - dupl
+    - bidichk
+    - bodyclose
+    - depguard
     - errcheck
-    - exhaustive
-    - gochecknoinits
-    - goconst
+    - forbidigo
+    - gocheckcompilerdirectives
     - gocritic
-    - gocyclo
-    - goprintffuncname
-    - gosec
     - govet
     - ineffassign
-    - lll
-    - misspell
+    - mirror
+    - modernize
     - nakedret
+    - nilnil
     - nolintlint
+    - perfsprint
+    - revive
     - staticcheck
+    - testifylint
     - unconvert
+    - unparam
     - unused
-    - whitespace
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: use os or io instead
+            - pkg: golang.org/x/exp
+              desc: it's experimental and unreliable
+            - pkg: github.com/pkg/errors
+              desc: use builtin errors package instead
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+    gocritic:
+      enabled-checks:
+        - equalFold
+      disabled-checks: []
+    revive:
+      severity: error
+      rules:
+        - name: blank-imports
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-lines
+        - name: error-return
+        - name: error-strings
+        - name: exported
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: modifies-value-receiver
+        - name: package-comments
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
+          disabled: true
+    staticcheck:
+      checks:
+        - all
+    testifylint: {}
+    usetesting:
+      os-temp-dir: true
+    perfsprint:
+      concat-loop: false
+    govet:
+      enable:
+        - nilness
+        - unusedwrite
   exclusions:
     generated: lax
     presets:
@@ -29,18 +91,24 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    rules:
+      - linters:
+          - errcheck
+          - staticcheck
+          - unparam
+        path: _test\.go
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 formatters:
   enable:
     - gofmt
     - gofumpt
-    - goimports
+    - golines
+  settings:
+    gofumpt:
+      extra-rules: true
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+run:
+  timeout: 10m

--- a/options.go
+++ b/options.go
@@ -75,8 +75,7 @@ func WithSkipTLSVerify() Option {
 	return func(w *options) {
 		if w.tls == nil {
 			w.tls = &tls.Config{
-				InsecureSkipVerify: true, //nolint: gosec
-
+				InsecureSkipVerify: true, //nolint:gosec // Explicitly requested to support self-signed certificates.
 			}
 			return
 		}

--- a/redis.go
+++ b/redis.go
@@ -24,7 +24,7 @@ type Worker struct {
 	rdb      redis.Cmdable
 	pubsub   *redis.PubSub
 	channel  <-chan *redis.Message
-	stopFlag int32
+	stopFlag atomic.Int32
 	stopOnce sync.Once
 	stop     chan struct{}
 	opts     options
@@ -118,7 +118,7 @@ func (w *Worker) Run(ctx context.Context, task core.TaskMessage) error {
 
 // Shutdown worker
 func (w *Worker) Shutdown() error {
-	if !atomic.CompareAndSwapInt32(&w.stopFlag, 0, 1) {
+	if !w.stopFlag.CompareAndSwap(0, 1) {
 		return queue.ErrQueueShutdown
 	}
 
@@ -137,7 +137,7 @@ func (w *Worker) Shutdown() error {
 
 // Queue send notification to queue
 func (w *Worker) Queue(job core.TaskMessage) error {
-	if atomic.LoadInt32(&w.stopFlag) == 1 {
+	if w.stopFlag.Load() == 1 {
 		return queue.ErrQueueShutdown
 	}
 
@@ -172,7 +172,7 @@ loop:
 			if clock == 5 {
 				break loop
 			}
-			clock += 1
+			clock++
 		}
 	}
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -24,8 +24,11 @@ import (
 const testMessage = "foo"
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
-		goleak.IgnoreTopFunction("github.com/redis/go-redis/v9/maintnotifications.(*CircuitBreakerManager).cleanupLoop"),
+	goleak.VerifyTestMain(
+		m,
+		goleak.IgnoreTopFunction(
+			"github.com/redis/go-redis/v9/maintnotifications.(*CircuitBreakerManager).cleanupLoop",
+		),
 	)
 }
 
@@ -75,7 +78,10 @@ func setupRedisSentinelContainer(
 	return redisC, endpoint
 }
 
-func setupRedisCluserContainer(ctx context.Context, t *testing.T) (testcontainers.Container, string) {
+func setupRedisCluserContainer(
+	ctx context.Context,
+	t *testing.T,
+) (testcontainers.Container, string) {
 	req := testcontainers.ContainerRequest{
 		Image: "vishnunair/docker-redis-cluster:latest",
 		ExposedPorts: []string{
@@ -87,7 +93,11 @@ func setupRedisCluserContainer(ctx context.Context, t *testing.T) (testcontainer
 			"6384/tcp",
 		},
 		WaitingFor: wait.NewExecStrategy(
-			[]string{"sh", "-c", "redis-cli -h localhost -p 6379 cluster info | grep -q cluster_state:ok"},
+			[]string{
+				"sh",
+				"-c",
+				"redis-cli -h localhost -p 6379 cluster info | grep -q cluster_state:ok",
+			},
 		),
 	}
 	redisC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -145,12 +155,12 @@ func TestRedisDefaultFlow(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(2),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(100 * time.Millisecond)
-	assert.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
 	m.Message = "bar"
-	assert.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
 	q.Shutdown()
 	q.Wait()
 }
@@ -168,12 +178,12 @@ func TestRedisShutdown(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(2),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(1 * time.Second)
 	q.Shutdown()
 	// check shutdown once
-	assert.Error(t, w.Shutdown())
+	require.Error(t, w.Shutdown())
 	assert.Equal(t, queue.ErrQueueShutdown, w.Shutdown())
 	q.Wait()
 }
@@ -198,10 +208,10 @@ func TestCustomFuncAndWait(t *testing.T) {
 		queue.WithWorker(w),
 	)
 	time.Sleep(100 * time.Millisecond)
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
 	time.Sleep(1000 * time.Millisecond)
 	q.Release()
 	// you will see the execute time > 1000ms
@@ -215,13 +225,13 @@ func TestRedisCluster(t *testing.T) {
 	defer testcontainers.CleanupContainer(t, redisC)
 
 	masterPort, err := redisC.MappedPort(ctx, "6379")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	slavePort, err := redisC.MappedPort(ctx, "6382")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	hostIP, err := redisC.Host(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m := &mockMessage{
 		Message: testMessage,
@@ -246,10 +256,10 @@ func TestRedisCluster(t *testing.T) {
 		queue.WithWorker(w),
 	)
 	time.Sleep(100 * time.Millisecond)
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
 	time.Sleep(1000 * time.Millisecond)
 	q.Release()
 	// you will see the execute time > 1000ms
@@ -264,18 +274,18 @@ func TestRedisSentinel(t *testing.T) {
 	redisC, _ := setupRedisContainer(ctx, t)
 	defer testcontainers.CleanupContainer(t, redisC)
 	masterPort, err := redisC.MappedPort(ctx, "6379")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	masterHost, err := redisC.Host(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sentinelC, _ := setupRedisSentinelContainer(ctx, t, masterHost, masterPort.Port())
 	defer testcontainers.CleanupContainer(t, sentinelC)
 
 	sentinelPort, err := sentinelC.MappedPort(ctx, "26379")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sentinelHost, err := sentinelC.Host(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m := &mockMessage{
 		Message: testMessage,
@@ -300,10 +310,10 @@ func TestRedisSentinel(t *testing.T) {
 		queue.WithWorker(w),
 	)
 	time.Sleep(100 * time.Millisecond)
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
 	time.Sleep(1000 * time.Millisecond)
 	q.Release()
 	// you will see the execute time > 1000ms
@@ -323,13 +333,13 @@ func TestEnqueueJobAfterShutdown(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(2),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(50 * time.Millisecond)
 	q.Shutdown()
 	// can't queue task after shutdown
 	err = q.Queue(m)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, queue.ErrQueueShutdown, err)
 	q.Wait()
 }
@@ -365,10 +375,10 @@ func TestJobReachTimeout(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(2),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(50 * time.Millisecond)
-	assert.NoError(t, q.Queue(m, job.AllowOption{
+	require.NoError(t, q.Queue(m, job.AllowOption{
 		Timeout: job.Time(20 * time.Millisecond),
 	}))
 	time.Sleep(2 * time.Second)
@@ -408,10 +418,10 @@ func TestCancelJobAfterShutdown(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(2),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(50 * time.Millisecond)
-	assert.NoError(t, q.Queue(m, job.AllowOption{
+	require.NoError(t, q.Queue(m, job.AllowOption{
 		Timeout: job.Time(3 * time.Second),
 	}))
 	time.Sleep(2 * time.Second)
@@ -454,17 +464,17 @@ func TestGoroutineLeak(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(10),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(50 * time.Millisecond)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		m.Message = fmt.Sprintf("foobar: %d", i+1)
-		assert.NoError(t, q.Queue(m))
+		require.NoError(t, q.Queue(m))
 	}
 	time.Sleep(1 * time.Second)
 	q.Release()
 	time.Sleep(1 * time.Second)
-	fmt.Println("number of goroutines:", runtime.NumGoroutine())
+	t.Log("number of goroutines:", runtime.NumGoroutine())
 }
 
 func TestGoroutinePanic(t *testing.T) {
@@ -485,13 +495,13 @@ func TestGoroutinePanic(t *testing.T) {
 		queue.WithWorker(w),
 		queue.WithWorkerCount(2),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	q.Start()
 	time.Sleep(50 * time.Millisecond)
-	assert.NoError(t, q.Queue(m))
-	assert.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
+	require.NoError(t, q.Queue(m))
 	time.Sleep(200 * time.Millisecond)
 	q.Shutdown()
-	assert.Error(t, q.Queue(m))
+	require.Error(t, q.Queue(m))
 	q.Wait()
 }


### PR DESCRIPTION
## Summary

- Replace the repository lint configuration with the current CodeGPT `.golangci.yml`.
- Update code, tests, and examples as needed for the expanded lint rules.
- Preserve runtime behavior while using current Go idioms and formatter output.

## Related issues

- Jira: N/A
- GitHub/Gitea: N/A

## Architecture / flow

```mermaid
flowchart TD
    Config[.golangci.yml] --> Lint[golangci-lint]
    Code[Updated Go code] --> Lint
    Tests[Updated tests and examples] --> Lint
    Lint --> Result[Zero lint findings]
    style Config fill:#dff0d8,stroke:#3c763d
    style Code fill:#dff0d8,stroke:#3c763d
    style Tests fill:#dff0d8,stroke:#3c763d
```

## AI authorship

- [ ] No AI was used
- [x] AI was used
  - **Tool / model**: Codex, GPT-5
  - **AI-authored files**: `.golangci.yml`, `options.go`, `redis.go`, `redis_test.go`
  - **Human line-by-line reviewed**: None — not yet reviewed by a human.

## Change classification

- [ ] Leaf change
- [x] Core change

## Plan reference

Adopt CodeGPT `.golangci.yml` verbatim and resolve all lint findings in scope.

## Verification

- **Automated**:
  - `golangci-lint config verify && golangci-lint run --timeout 10m` — passed
  - `go test -run '^$' ./...` — passed
  - `git diff --check` — passed
- **Manual**: No manual runtime test performed.
- **Not run**: `go test ./...` was attempted after starting Colima, but testcontainers could not pull Docker Hub images because the local Docker runtime rejects the registry certificate: `x509: certificate signed by unknown authority`. Retry in CI or after repairing the local Docker CA trust.

## Security check

- [x] No secrets in the diff
- [ ] External inputs are validated
- [ ] Permission checks are tested
- [ ] Errors do not leak internals
- [x] N/A - no external or security-sensitive interface changed

## Risk and rollback

- **Risk**: The stricter lint baseline may expose further findings in future code changes.
- **Rollback**: Revert this PR's single commit.

## Reviewer guide

- **Read carefully**: The lint configuration and atomic/test assertion updates.
- **Spot-check**: Mechanical formatter changes in tests and examples.